### PR TITLE
Auto-resize columns

### DIFF
--- a/themes/poster.css
+++ b/themes/poster.css
@@ -161,7 +161,7 @@ column in half again */
 than the others. */
 .columns-main {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(10%, 1fr));
   gap: 0.75in;
   padding: 0.125in;
   overflow: hidden;
@@ -171,7 +171,7 @@ than the others. */
 /* This is what I used to create a top bar of main points for the poster */
 .columns-box {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(10%, 1fr));
   gap: 0.5in;
   padding: 0.125in 0.25in;
 }


### PR DESCRIPTION
`.columns-main` and `.columns-box` have fixed number of columns (3 and 5, respectively). This will accomodate for arbitrary number of columns i.e. 2 columns in main body.

Quick check with Tommy's example poster didnt change the output. Below is the output with auto resize.

![nebec2](https://user-images.githubusercontent.com/5142539/169587209-b2f3a2ac-35be-47dc-9cde-c5dac1700443.png)

